### PR TITLE
Uncover missing error in Affect.throw test

### DIFF
--- a/test/Test_Affect.re
+++ b/test/Test_Affect.re
@@ -97,7 +97,13 @@ describe("Affect", () => {
           /* Did not throw */
           fail("Async effect should have failed");
           done_()
-        }) { | Js.Exn.Error(_) => done_() }
+        }) { | Js.Exn.Error(e) => {
+          switch (Js.Exn.message(e)) {
+            | Some(message) => expect(message) |> to_match([%bs.re "/ENOENT/g"])
+            | _ => fail("Expected error was not thrown")
+          }
+          done_()
+        }}
       })
     });
 


### PR DESCRIPTION
Test that expected error was thrown, rather than that _any_ error was thrown. In the original version, the error `"Async effect should have failed"` was being caught and causing the test to pass erroneously.

re: #1